### PR TITLE
refactor: Simplify CLI commands + add MCP link/unlink

### DIFF
--- a/scripts/stress_test_1gb.py
+++ b/scripts/stress_test_1gb.py
@@ -26,7 +26,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from kameleondb import KameleonDB
 
-
 # =============================================================================
 # Data Generation
 # =============================================================================
@@ -291,7 +290,7 @@ class StressTest:
         total_bytes += customer_bytes
         self.log(f"  Generated in {gen_time:.1f}s ({customer_bytes / 1024 / 1024:.1f} MB)")
 
-        self.log(f"Inserting customers...")
+        self.log("Inserting customers...")
         start = time.time()
         customer_entity = self.db.entity("Customer")
         for i in range(0, len(customers), self.BATCH_SIZE):
@@ -315,7 +314,7 @@ class StressTest:
         total_bytes += product_bytes
         self.log(f"  Generated in {gen_time:.1f}s ({product_bytes / 1024 / 1024:.1f} MB)")
 
-        self.log(f"Inserting products...")
+        self.log("Inserting products...")
         start = time.time()
         product_entity = self.db.entity("Product")
         for i in range(0, len(products), self.BATCH_SIZE):
@@ -526,7 +525,7 @@ class StressTest:
     def run(self) -> dict:
         """Run the full stress test."""
         self.log("=" * 60)
-        self.log(f"Starting 1GB Stress Test")
+        self.log("Starting 1GB Stress Test")
         self.log("=" * 60)
 
         overall_start = time.time()


### PR DESCRIPTION
## Summary

Pre-release cleanup to reduce CLI complexity and align CLI/MCP feature parity.

## CLI Changes

### Commands Merged

| Before | After | Notes |
|--------|-------|-------|
| `link` + `link-many` | `link` | Single command with `-t` for batch |
| `unlink` + `unlink-many` | `unlink` | Single command with `-t` or `--all` |
| `add-field` + `drop-field` | `alter` | Unified with `--add`, `--drop`, `--rename` |

### Commands Renamed

| Before | After |
|--------|-------|
| `schema stats` | `schema info` |
| `data stats` | `data info` |

### Commands Removed

- `query validate` — rarely used, `query run` handles validation

### Command Count

**31 → 27** (4 commands removed)

## MCP Additions

Added missing M2M tools to match CLI:
- `kameleondb_link` — link records in M2M relationships
- `kameleondb_unlink` — unlink records (supports batch and unlink_all)

## New CLI Examples

```bash
# Link (single or batch)
kameleondb data link Product abc123 tags tag1
kameleondb data link Product abc123 tags -t tag1 -t tag2 -t tag3

# Unlink (single, batch, or all)
kameleondb data unlink Product abc123 tags tag1
kameleondb data unlink Product abc123 tags -t tag1 -t tag2
kameleondb data unlink Product abc123 tags --all

# Alter (unified schema evolution)
kameleondb schema alter Contact --add "phone:string:indexed"
kameleondb schema alter Contact --drop legacy_field --force
kameleondb schema alter Contact --add "new:string" --drop old --reason "Cleanup"
```

## Tests

All 235 tests pass ✅