### PR TITLE
fix: resolve mypy type error in find_all() orm_records variable

### DIFF
--- a/src/kameleondb/data/jsonb_query.py
+++ b/src/kameleondb/data/jsonb_query.py
@@ -403,7 +403,7 @@ class JSONBQuery:
             else:
                 # Query from shared storage (kdb_records)
                 with Session(self._engine) as session:
-                    records = (
+                    orm_records = (
                         session.query(Record)
                         .filter(Record.entity_id == self._entity_id)
                         .filter(Record.is_deleted == False)  # noqa: E712
@@ -411,7 +411,7 @@ class JSONBQuery:
                         .all()
                     )
 
-                    return [self._record_to_dict(r) for r in records]
+                    return [self._record_to_dict(r) for r in orm_records]
         except Exception as e:
             raise QueryError(f"Failed to find records: {e}") from e
 


### PR DESCRIPTION
## Problem

All open PRs (#61, #63, #64) and `main` are failing the lint CI check due to a mypy type error in `jsonb_query.py`:

```
src/kameleondb/data/jsonb_query.py:407: error: Incompatible types in assignment (expression has type "list[Record]", variable has type "list[dict[str, Any]]")
src/kameleondb/data/jsonb_query.py:414: error: Argument 1 to "_record_to_dict" ... has incompatible type "dict[str, Any]"; expected "Record"
```

## Root Cause

In `find_all()`, the `records` variable is first assigned as `list[dict[str, Any]]` (the dedicated-table branch). In the `else` branch (shared storage), the same variable name was reused for `session.query(Record).all()` which returns `list[Record]` — causing a type mismatch.

## Fix

Rename the SQLAlchemy query result to `orm_records` in the shared-storage branch to avoid the variable type collision. One-line change.

## Testing

```
uv run mypy src/  # ✅ Success: no issues found
uv run ruff check src tests  # ✅ All checks passed
uv run ruff format --check src tests  # ✅ All checks passed
```